### PR TITLE
Pull images to work around bollard issue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -59,6 +59,10 @@ steps:
   # Run cheap sanity tests against selected builtin extensions
   - label: ":docker: Builtin tests"
     commands:
+      # HACK: pre-19.03 engines (verified on 18.09) will crash Bollard if an image needs
+      # to be pulled during an image build, so we do it ahead of time until our builders
+      # are upgraded to the 19.03 daemon.
+      - docker pull php:7.3-cli-alpine
       - chmod +x target/debug/builtin
       - target/debug/builtin
     plugins:
@@ -70,6 +74,8 @@ steps:
   # Run sanity tests against PECL extensions
   - label: ":docker: PECL tests"
     commands:
+      # See note above for why we're pulling before testing
+      - docker pull php:7.3-cli-alpine
       - chmod +x target/debug/pecl
       - target/debug/pecl
     plugins:


### PR DESCRIPTION
During the integration tests, some versions of Docker (verified with 18.09) will crash the test if an image is pulled. For some reason, the response data that gets sent back will fail to parse as valid JSON when a pulled image is extracted:

```
BuildImageStatus { status: "Extracting", progress_detail: Some(BuildImageProgressDetail { current: Some(163840), total: Some(14849941) }), progress: Some("[>                                                  ]  163.8kB/14.85MB"), id: Some("ff2b3ea4324b") }
thread 'test_external_pecl_config' panicked at 'called `Result::unwrap()` on an `Err` value: Error { inner:
 
Failed to deserialize JSON: {"status":"Extracting","progressDetail":{"current":2457600,"total":14849941},"progress":"[========\u003e                     : Error("EOF while parsing a string", line: 1, column: 125) }', src/libcore/result.rs:1165:5
```

Ultimately, it looks like the progress bar that comes back is either corrupt, or incorrectly rejected by the underlying JSON parser. I'll be filing an issue upstream against the crate to see if the issue can be pinned down.

This PR addresses the issue by pulling the image used in testing first, before any builds are dispatched. This will work around the problem until our build servers are updated to use 19.03, which doesn't have this issue.