### PR TITLE
Fix GD build for PHP 7.4

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,6 +63,7 @@ steps:
       # to be pulled during an image build, so we do it ahead of time until our builders
       # are upgraded to the 19.03 daemon.
       - docker pull php:7.3-cli-alpine
+      - docker pull php:7.7-cli-alpine
       - chmod +x target/debug/builtin
       - target/debug/builtin
     plugins:
@@ -76,6 +77,7 @@ steps:
     commands:
       # See note above for why we're pulling before testing
       - docker pull php:7.3-cli-alpine
+      - docker pull php:7.7-cli-alpine
       - chmod +x target/debug/pecl
       - target/debug/pecl
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,7 +63,7 @@ steps:
       # to be pulled during an image build, so we do it ahead of time until our builders
       # are upgraded to the 19.03 daemon.
       - docker pull php:7.3-cli-alpine
-      - docker pull php:7.7-cli-alpine
+      - docker pull php:7.4-cli-alpine
       - chmod +x target/debug/builtin
       - target/debug/builtin
     plugins:
@@ -77,7 +77,7 @@ steps:
     commands:
       # See note above for why we're pulling before testing
       - docker pull php:7.3-cli-alpine
-      - docker pull php:7.7-cli-alpine
+      - docker pull php:7.4-cli-alpine
       - chmod +x target/debug/pecl
       - target/debug/pecl
     plugins:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "f1-ext-install"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "bollard 0.4.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "f1-ext-install"
 description = "Helper for building PHP extensions in Docker"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["gustavderdrache <aford@forumone.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"

--- a/src/extension/builtin.rs
+++ b/src/extension/builtin.rs
@@ -56,6 +56,11 @@ lazy_static! {
                 String::from("libjpeg-turbo-dev"),
             ]),
             configure_cmd: Some(vec![
+                // Skip option checking while we still support pre-7.4 PHPs - this is a
+                // pretty bad idea in general, but since we're applying it only to the GD
+                // extension in particular, we should be relatively safe.
+                String::from("--disable-option-checking"),
+
                 String::from("--with-freetype-dir=/usr/include/"),
                 String::from("--with-jpeg-dir=/usr/include/"),
                 String::from("--with-png-dir=/usr/include/"),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,7 +8,7 @@ use tokio_test::block_on;
 pub const F1_EXT_INSTALL_PATH: &str = "target/x86_64-unknown-linux-musl/debug/f1-ext-install";
 
 /// PHP versions to run integration tests against.
-pub const PHP_VERSIONS: &[&str] = &["7.3"];
+pub const PHP_VERSIONS: &[&str] = &["7.3", "7.4"];
 
 /// Create a Docker client that is connected to the local daemon.
 pub fn connect() -> Docker {


### PR DESCRIPTION
This PR skips option checking for GD. As mentioned in the code comment, this isn't normally a good idea, but as it is localized to just the GD extension, it should be relatively safe. Once we start removing support for older PHP versions in this program, we can revisit the installation method for this extension.