### PR TITLE
Add more builtin extensions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  RUST_VERSION: '1.39'
+  RUST_VERSION: '1.41'
 
 steps:
   - label: ":rust: Lint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "f1-ext-install"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "bollard 0.4.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "f1-ext-install"
 description = "Helper for building PHP extensions in Docker"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["gustavderdrache <aford@forumone.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.39-slim AS deps
+FROM rust:1.41-slim AS deps
 
 RUN rustup target add x86_64-unknown-linux-musl
 

--- a/src/extension/builtin.rs
+++ b/src/extension/builtin.rs
@@ -48,7 +48,46 @@ impl Builtin {
 }
 
 lazy_static! {
+    // NB. A few extensions are indicated in comments but not explicitly listed:
+    // - A "no need" comment just means that there are no external dependencies
+    //   for the extension, so we let BuiltinData::default() handle it.
+    // - An "already loaded" comment means that for php:7.4-cli-alpine, the test
+    //   extension_loaded("<name>") returns true, and we assume we don't need to add it.
+    // - A "TODO" comment indicates that we can add the extension, but there may not be a
+    //   need, so we've avoided adding it to the built-in registry for now.
     static ref REGISTRY: BTreeMap<&'static str, BuiltinData> = btreemap! {
+        // bcmath: no need
+
+        "bz2" => BuiltinData {
+            packages: Some(vec![
+                String::from("bzip2-dev"),
+            ]),
+            configure_cmd: Some(vec![
+                String::from("--with-bz2")
+            ]),
+        },
+
+        // calendar: no need
+
+        // ctype: already loaded
+        // curl: already loaded
+        // dom: already loaded
+
+        "enchant" => BuiltinData {
+            packages: Some(vec![
+                String::from("enchant-dev")
+            ]),
+            configure_cmd: Some(vec![
+                String::from("--with-enchant"),
+            ]),
+        },
+
+        // exif: no need
+
+        // fileinfo: already loaded
+        // filter: already loaded
+        // ftp: already loaded
+
         "gd" => BuiltinData {
             packages: Some(vec![
                 String::from("coreutils"),
@@ -67,10 +106,84 @@ lazy_static! {
             ]),
         },
 
+        "gettext" => BuiltinData {
+            packages: Some(vec![
+                String::from("gettext"),
+                String::from("gettext-dev"),
+            ]),
+            configure_cmd: Some(vec![
+                String::from("--with-gettext")
+            ]),
+        },
+
+        "gmp" => BuiltinData {
+            packages: Some(vec![
+                String::from("gmp-dev"),
+            ]),
+            configure_cmd: Some(vec![
+                String::from("--with-gmp")
+            ]),
+        },
+
+        // iconv: already loaded
+
+        "imap" => BuiltinData {
+            packages: Some(vec![
+                String::from("imap-dev"),
+                String::from("openssl-dev"),
+            ]),
+            configure_cmd: Some(vec![
+                String::from("--with-imap"),
+                String::from("--with-imap-ssl"),
+            ]),
+        },
+
+        "intl" => BuiltinData {
+            packages: Some(vec![
+                String::from("icu-dev"),
+            ]),
+            ..BuiltinData::default()
+        },
+
+        // json: already loaded
+
+        "ldap" => BuiltinData {
+            packages: Some(vec![
+                String::from("openldap-dev")
+            ]),
+            configure_cmd: Some(vec![
+                String::from("--with-ldap"),
+                String::from("--with-ldap-sasl"),
+            ]),
+        },
+
+        // mbstring: already loaded
+        // mysqli: no need
+        // mysqlnd: no need
+        // opcache: no need
+        // pcntl: no need
+        // phar: no need
+        // pdo: already loaded
+        // pdo_mysql: no need
+        // pdo_pgsql: TODO
+        // posix: already loaded
+        // pspell: TODO
+        // session: already loaded
+        // simplexml: already loaded
+
         "soap" => BuiltinData {
             packages: Some(vec![String::from("libxml2-dev")]),
             ..BuiltinData::default()
         },
+
+        // sodium: already loaded
+        // sqlite3: already loaded
+        // tokenizer: already loaded
+        // xml: already loaded
+        // xmlreader: already loaded
+        // xmlrpc: TODO
+        // xmlwriter: already loaded
+        // xsl: TODO
 
         "zip" => BuiltinData {
             packages: Some(vec![String::from("libzip-dev")]),

--- a/tests/builtin.rs
+++ b/tests/builtin.rs
@@ -17,25 +17,57 @@ const REGISTRY_DOCKERFILE: &str = indoc!(
        RUN php -r "if (!extension_loaded(getenv('PACKAGE_NAME'))) exit(1);""#
 );
 
-#[test]
-fn test_builtins_from_registry() {
-    let client = connect();
+/// Shorthand macro to define a test for a builtin from the registry. Takes an extension
+/// name (as a Rust identifier) as its only argument.
+///
+/// This macro exists for two reasons:
+/// 1. It abstracts away the boilerplate of setting up a test for a new builtin added to
+/// the internal registry and
+/// 2. It enables us to separate tests for each extension.
+///
+/// The cargo test infrastructure gets somewhat cranky when we run a test for too long,
+/// so this macro helps us split the tests up with extremely minimal repetition.
+///
+/// For example, given this invocation:
+///
+/// ```
+/// define_registry_test!(bz2);
+/// ```
+///
+/// The macro expands to a test function named `bz2` that installs `builtin:bz2` in a
+/// Docker build test.
+macro_rules! define_registry_test {
+    ($builtin:ident) => {
+        #[test]
+        fn $builtin() {
+            let client = connect();
 
-    let builtins = &["gd", "soap", "zip"];
+            let builtin = stringify!($builtin);
 
-    for &builtin in builtins {
-        for &version in PHP_VERSIONS {
-            let tag = tag_for_test("builtin", builtin, version);
+            for &version in PHP_VERSIONS {
+                let tag = tag_for_test("builtin", builtin, version);
 
-            build_image(
-                &client,
-                REGISTRY_DOCKERFILE,
-                &[("PACKAGE_NAME", builtin), ("PHP_VERSION", version)],
-                &tag,
-            );
+                build_image(
+                    &client,
+                    REGISTRY_DOCKERFILE,
+                    &[("PACKAGE_NAME", builtin), ("PHP_VERSION", version)],
+                    &tag,
+                );
+            }
         }
-    }
+    };
 }
+
+define_registry_test!(bz2);
+define_registry_test!(enchant);
+define_registry_test!(gd);
+define_registry_test!(gettext);
+define_registry_test!(gmp);
+define_registry_test!(imap);
+define_registry_test!(intl);
+define_registry_test!(ldap);
+define_registry_test!(soap);
+define_registry_test!(zip);
 
 const EXTERNAL_DOCKERFILE: &str = indoc!(
     r#"ARG PHP_VERSION
@@ -59,33 +91,75 @@ const EXTERNAL_DOCKERFILE: &str = indoc!(
        RUN php -r "if (!extension_loaded(getenv('PACKAGE_NAME'))) exit(1);""#
 );
 
-#[test]
-fn test_external_builtin_config() {
-    let client = connect();
+/// Shorthand to define a test for a PHP builtin that relies on external configuration.
+/// Takes an extension name (as a Rust identifier) plus configuration as its parameters
+/// (see below).
+///
+/// As with `define_builtin_test` above, this macro attemps to reduce boilerplate and
+/// split each builtin test into its own #[test] function.
+///
+/// The syntax is as follows:
+///
+/// ```no_run
+/// define_external_test!(
+///     // The name of the builtin being tested, as a Rust identifier
+///     ext,
+///
+///     // The environment variable needed to specify packages to install.
+///     F1_BUILTIN_EXT_PACKAGES = "foo,bar",
+///
+///     // The environment variable specifying the configure flags that are needed.
+///     F1_BUILTIN_EXT_CONFIGURE_ARGS = "--with-ext",
+/// );
+/// ```
+///
+/// Like `define_builtin_test`, this macro expands to a single test function named after
+/// the extension under test.
+///
+/// Note that the `FOO = "foo"` syntax is required by the macro; it is designed to mimic
+/// the shell/Dockerfile needed to install the package.
+macro_rules! define_external_test {
+    (
+        // The extension name
+        $name:ident,
+        // The ENV_VAR = "value" for which packages (if any) to install
+        $pkgs_key:ident = $pkgs_val:tt,
+        // The ENV_VAR = "value" for additional configure flags (if any)
+        $conf_key:ident = $conf_val:tt $(,)?
+    ) => {
+        #[test]
+        fn $name() {
+            let client = connect();
 
-    let packages = &[(
-        "ldap",
-        ("F1_BUILTIN_LDAP_PACKAGES", "openldap-dev"),
-        ("F1_BUILTIN_LDAP_CONFIGURE_ARGS", "--with-ldap"),
-    )];
+            let package = stringify!($name);
+            let packages_key = stringify!($pkgs_key);
+            let packages_value = stringify!($packages_value);
+            let configure_key = stringify!($conf_key);
+            let configure_value = stringify!($conf_val);
 
-    for &(package, (packages_key, packages_value), (configure_key, configure_value)) in packages {
-        for &version in PHP_VERSIONS {
-            let tag = tag_for_test("builtin", package, version);
+            for &version in PHP_VERSIONS {
+                let tag = tag_for_test("builtin", package, version);
 
-            build_image(
-                &client,
-                EXTERNAL_DOCKERFILE,
-                &[
-                    ("PACKAGE_NAME", package),
-                    ("PHP_VERSION", version),
-                    ("PACKAGES_KEY", packages_key),
-                    ("PACKAGES_VALUE", packages_value),
-                    ("CONFIGURE_KEY", configure_key),
-                    ("CONFIGURE_VALUE", configure_value),
-                ],
-                &tag,
-            );
+                build_image(
+                    &client,
+                    EXTERNAL_DOCKERFILE,
+                    &[
+                        ("PACKAGE_NAME", package),
+                        ("PHP_VERSION", version),
+                        ("PACKAGES_KEY", packages_key),
+                        ("PACKAGES_VALUE", packages_value),
+                        ("CONFIGURE_KEY", configure_key),
+                        ("CONFIGURE_VALUE", configure_value),
+                    ],
+                    &tag,
+                );
+            }
         }
-    }
+    };
 }
+
+define_external_test!(
+    ffi,
+    F1_BUILTIN_FFI_PACKAGES = "libffi-dev",
+    F1_BUILTIN_FFI_CONFIGURE_ARGS = "--with-ffi",
+);


### PR DESCRIPTION
This PR adds a few more builtin extensions to the internal registry. This list isn't complete, but it should be enough to cover most of the extensions we encounter for site builds.

Other changes:

1. Rust is bumped to 1.41, the latest.
2. The builtin tests have been refactored to use a macro for easier management; as a result, we test a lot more of the extensions to ensure they can compile out of the box.
3. The tool version has been bumped to 0.5.0, which we can deploy to our base PHP images once this build has finished pushing to the Docker Hub.