### PR TITLE
Ensure all GD features are available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "f1-ext-install"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "bollard 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "f1-ext-install"
 description = "Helper for building PHP extensions in Docker"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["gustavderdrache <aford@forumone.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"

--- a/src/extension/builtin.rs
+++ b/src/extension/builtin.rs
@@ -100,9 +100,18 @@ lazy_static! {
                 // extension in particular, we should be relatively safe.
                 String::from("--disable-option-checking"),
 
-                String::from("--with-freetype-dir=/usr/include/"),
-                String::from("--with-jpeg-dir=/usr/include/"),
-                String::from("--with-png-dir=/usr/include/"),
+                // Configuration for PHP >= 7.4: these options tell configure to use
+                // pkg-config to find the needed compiler flags
+                String::from("--with-freetype"),
+                String::from("--with-jpeg"),
+                String::from("--with-png"),
+
+                // Configuration for PHP < 7.3 needs the --with-foo-dir options instead,
+                // which looks looks for files starting with this prefix (e.g., passing
+                // --with-foo-dir=/usr looks for foo.h inside of /usr/include, and so on.)
+                String::from("--with-freetype-dir=/usr"),
+                String::from("--with-jpeg-dir=/usr"),
+                String::from("--with-png-dir=/usr"),
             ]),
         },
 

--- a/src/extension/pecl.rs
+++ b/src/extension/pecl.rs
@@ -94,7 +94,7 @@ fn find_pecl_data(name: &str) -> PeclData {
         return found.clone();
     }
 
-    let prefix = format!("F1_PECL_{}", name.to_ascii_uppercase());
+    let prefix = format!("F1_PECL_{}_", name.to_ascii_uppercase());
     if let Ok(data) = envy::prefixed(prefix).from_env() {
         return data;
     }

--- a/tests/builtin.rs
+++ b/tests/builtin.rs
@@ -150,12 +150,27 @@ const EXTERNAL_DOCKERFILE: &str = indoc!(
 /// the shell/Dockerfile needed to install the package.
 macro_rules! define_external_test {
     (
+        $name:ident,
+        $pkgs_key:ident = $pkgs_val:tt,
+        $conf_key:ident = $conf_val:tt $(,)?
+    ) => {
+        define_external_test!(
+            $name,
+            $pkgs_key = $pkgs_val,
+            $conf_key = $conf_val,
+            versions = PHP_VERSIONS
+        );
+    };
+
+    (
         // The extension name
         $name:ident,
         // The ENV_VAR = "value" for which packages (if any) to install
         $pkgs_key:ident = $pkgs_val:tt,
         // The ENV_VAR = "value" for additional configure flags (if any)
-        $conf_key:ident = $conf_val:tt $(,)?
+        $conf_key:ident = $conf_val:tt,
+        // List of versions to iterate over (useful for, e.g., limiting tests to 7.4)
+        versions = $versions:expr $(,)?
     ) => {
         #[test]
         fn $name() {
@@ -163,11 +178,11 @@ macro_rules! define_external_test {
 
             let package = stringify!($name);
             let packages_key = stringify!($pkgs_key);
-            let packages_value = stringify!($packages_value);
+            let packages_value = $pkgs_val;
             let configure_key = stringify!($conf_key);
-            let configure_value = stringify!($conf_val);
+            let configure_value = $conf_val;
 
-            for &version in PHP_VERSIONS {
+            for &version in $versions {
                 let tag = tag_for_test("builtin", package, version);
 
                 build_image(
@@ -192,4 +207,5 @@ define_external_test!(
     ffi,
     F1_BUILTIN_FFI_PACKAGES = "libffi-dev",
     F1_BUILTIN_FFI_CONFIGURE_ARGS = "--with-ffi",
+    versions = &["7.4"]
 );

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,7 @@
-use bollard::{image::BuildImageOptions, Docker};
+use bollard::{
+    image::{BuildImageOptions, BuildImageResults},
+    Docker,
+};
 use futures::StreamExt as _;
 use std::convert::TryInto as _;
 use tar::{Builder, Header};
@@ -52,8 +55,14 @@ pub fn build_image(client: &Docker, dockerfile: &str, args: &[(&str, &str)], tag
         while let Some(result) = stream.next().await {
             let result = match result {
                 Ok(result) => result,
-                Err(err) => return Err(err),
+                Err(err) => return Err(err.to_string()),
             };
+
+            // Errors during `RUN` are propagated as BuildImageError, so we return the
+            // value as an error message to the block_on() function.
+            if let BuildImageResults::BuildImageError { ref error, .. } = result {
+                return Err(error.clone());
+            }
 
             println!("{:?}", result);
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -69,6 +69,7 @@ pub fn build_image(client: &Docker, dockerfile: &str, args: &[(&str, &str)], tag
 
         Ok(())
     })
+    .map_err(|error| format!("Failed to build {}: {}", tag, error))
     .unwrap();
 }
 

--- a/tests/pecl.rs
+++ b/tests/pecl.rs
@@ -69,7 +69,7 @@ fn test_external_pecl_config() {
                 &client,
                 EXTERNAL_DOCKERFILE,
                 &[
-                    ("PACKAGE_NAME", "ldap"),
+                    ("PACKAGE_NAME", "mcrypt"),
                     ("PHP_VERSION", version),
                     ("PACKAGES_KEY", packages_key),
                     ("PACKAGES_VALUE", packages_value),


### PR DESCRIPTION
This PR adds a few things:

1. A test has been added to ensure that whenever GD is installed, it has support for JPEG, PNG, and FreeType - these are needed by Drupal for image styles.
2. The configure flags for gd with PHP 7.4 have been corrected.
3. Some small improvements to the `build_image()` harness - when a test fails, the error message includes the tag of the image that failed to build (which will indicate the PHP version that couldn't build).